### PR TITLE
Added " to time offset in timeShift() series name

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2489,7 +2489,7 @@ def timeShift(requestContext, seriesList, timeShift, resetEnd=True):
     series = seriesList[0]
 
     for shiftedSeries in evaluateTarget(myContext, series.pathExpression):
-      shiftedSeries.name = 'timeShift(%s, %s)' % (shiftedSeries.name, timeShift)
+      shiftedSeries.name = 'timeShift(%s, "%s")' % (shiftedSeries.name, timeShift)
       if resetEnd:
         shiftedSeries.end = series.end
       else:


### PR DESCRIPTION
If you request a series with timeshift:
timeShift(my.data.series, "-2d")

Currently timeShift returns the series name without quotes:
timeShift(my.data.series, -2d)

This change adds " around the second parameter so the returned target name is valid
timeShift(my.data.series, \"-2d\")

To reproduce: Request any timeShift and look at the returned json target name.
